### PR TITLE
Fix simultaneous send requests while obtaining token

### DIFF
--- a/lib/wns.js
+++ b/lib/wns.js
@@ -248,7 +248,7 @@ var sendNotificationNow = function (context) {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'text/xml',
-			'Content-Length': context.payload.length,
+			'Content-Length': Buffer.byteLength(context.payload, 'utf8'),
 			'X-WNS-Type': context.type,
 			'Authorization': 'Bearer ' + accessToken
 		}


### PR DESCRIPTION
If you are sending a push notification for the first time, a token will be retrieved. During that time, if you attempt to send another message, it gets queued, but produces a fatal error. This is because a new request for a new token is made.

Another fix for UTF-8 messages.
