### PR TITLE
Allow values >99 and equal to 0 in sendBadge.

### DIFF
--- a/lib/wns.js
+++ b/lib/wns.js
@@ -454,11 +454,11 @@ exports.sendBadge = function () {
 		throw new Error('The badge value must be a string or a number.');
 
 	if (!isNaN(realValue)) {
-		if (realValue < 1 || realValue > 99)
-			throw new Error('The badge numeric value must be in the 1-99 range.');
+		if (realValue < 0) //Values greater than 99 appear as 99+, 0 clears the badge
+			throw new Error('The badge numeric value must be greater than or equal to 0.');
 	}
 	else if (!badges.some(function (badge) { return badge === realValue; })) 
-		throw new Error('The badge value must be either an integer in the 1-99 range or one of '  
+		throw new Error('The badge value must be either an integer greater than or equal to 0 or one of '  
 			+ JSON.stringify(badges));
 
 	var badge = '<badge value="' + realValue + '" version="' + realVersion + '"/>';


### PR DESCRIPTION
From MSDN: "A value of 0 clears the badge, values from 1-99 display as
given, and any value greater than 99 displays as 99+."
http://msdn.microsoft.com/en-us/library/windows/apps/br212849.aspx
